### PR TITLE
Moved build output to /lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Build files
-prop-types.js
+lib
 
 # Logs
 logs

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-peek",
   "version": "1.0.5",
   "description": "Gather data by inspecting react components.",
-  "main": "prop-types.js",
+  "main": "lib/prop-types.js",
   "keywords": [
     "react",
     "prop-types",
@@ -18,7 +18,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "babel-prop-types": "babel src/prop-types.js > prop-types.js",
+    "babel-prop-types": "babel src -d lib",
     "prepublish": "npm run babel-prop-types"
   },
   "dependencies": {

--- a/prop-types.js
+++ b/prop-types.js
@@ -1,0 +1,2 @@
+// Support for require('react-peek/prop-types')
+require('./lib/prop-types');


### PR DESCRIPTION
This change moves build output to /lib but maintains compatibility with path includes like 'react-peek/prop-types'